### PR TITLE
Update label name in `scan_id` column

### DIFF
--- a/Docker/score.py
+++ b/Docker/score.py
@@ -64,7 +64,7 @@ def extract_metrics(tmp, scan_id):
                        "Sensitivity", "Specificity"])
         .filter(items=["ET", "WT", "TC"], axis=0)
         .reset_index()
-        .assign(scan_id=scan_id)
+        .assign(scan_id=f"BraTS2021_{scan_id}")
         .pivot(index="scan_id", columns="Labels")
     )
     res.columns = ["_".join(col).strip() for col in res.columns.values]


### PR DESCRIPTION
Per Ujjwal's request:

> In scan_id column, can we have complete name of the case?
>
> For example, currently we have 1, 13, 15 etc. Can we have BraTS2021_00001, BraTS2021_00013, BraTS21_00015?