### PR TITLE
update error handling to give penalized scores

### DIFF
--- a/Docker/score.py
+++ b/Docker/score.py
@@ -112,7 +112,7 @@ def main():
     # segmentation that could not be scored, and number of segmentations
     # that were scored.
     cases_predicted = len(results.index)
-    flagged_cases = results.scan_id.str.count("\*").sum()
+    flagged_cases = results.scan_id.str.count(r"\*").sum()
     cases_evaluated = cases_predicted - flagged_cases
 
     results.loc["mean"] = results.mean()
@@ -132,7 +132,6 @@ def main():
     with open(args.output, "w") as out:
         out.write(json.dumps(
             {**results.loc["mean"].to_dict(),
-                "cases_predicted": cases_predicted,
                 "cases_evaluated": cases_evaluated,
                 "submission_scores": csv.id,
                 "submission_status": "SCORED"}

--- a/Docker/score.py
+++ b/Docker/score.py
@@ -77,10 +77,25 @@ def score(parent, pred_lst, captk_path, tmp_output="tmp.csv"):
     for pred in pred_lst:
         scan_id = pred[-12:-7]
         gold = os.path.join(parent, f"BraTS2021_{scan_id}_seg.nii.gz")
-        run_captk(captk_path, pred, gold, tmp_output)
-        scan_scores = extract_metrics(tmp_output, scan_id)
+        try:
+            run_captk(captk_path, pred, gold, tmp_output)
+            scan_scores = extract_metrics(tmp_output, scan_id)
+            os.remove(tmp_output)  # Remove file, as it's no longer needed
+        except subprocess.CalledProcessError:
+            # If no output found, give penalized scores.
+            scan_scores = (
+                pd.DataFrame({
+                    "scan_id": [f"BraTS2021_{scan_id}*"],
+                    "Dice_ET": [0], "Dice_TC": [0], "Dice_WT": [0],
+                    "Hausdorff95_ET": [374], "Hausdorff95_TC": [374],
+                    "Hausdorff95_WT": [374], "Sensitivity_ET": [0],
+                    "Sensitivity_TC": [0], "Sensitivity_WT": [0],
+                    "Specificity_ET": [0], "Specificity_TC": [0],
+                    "Specificity_WT": [0]
+                })
+                .set_index("scan_id")
+            )
         scores.append(scan_scores)
-        os.remove(tmp_output)  # Remove file, as it's no longer needed
     return pd.concat(scores).sort_values(by="scan_id")
 
 
@@ -91,39 +106,37 @@ def main():
     golds = utils.unzip_file(args.goldstandard_file)
 
     dir_name = os.path.split(golds[0])[0]
-    try:
-        results = score(dir_name, preds, args.captk_path)
-        cases = len(results.index)
-        results.loc["mean"] = results.mean()
-        results.loc["sd"] = results.std()
-        results.loc["median"] = results.median()
-        results.loc["25quantile"] = results.quantile(q=0.25)
-        results.loc["75quantile"] = results.quantile(q=0.75)
+    results = score(dir_name, preds, args.captk_path)
 
-        # CSV file of scores for all scans.
-        results.to_csv("all_scores.csv")
-        syn = synapseclient.Synapse(configPath=args.synapse_config)
-        syn.login(silent=True)
-        csv = synapseclient.File("all_scores.csv", parent=args.parent_id)
-        csv = syn.store(csv)
+    # Get number of segmentations predicted by participant, number of
+    # segmentation that could not be scored, and number of segmentations
+    # that were scored.
+    cases_predicted = len(results.index)
+    flagged_cases = results.scan_id.str.count("\*").sum()
+    cases_evaluated = cases_predicted - flagged_cases
 
-        # Results file for annotations.
-        with open(args.output, "w") as out:
-            out.write(json.dumps(
-                {**results.loc["mean"].to_dict(),
-                 "cases_evaluated": cases,
-                 "submission_scores": csv.id,
-                 "submission_status": "SCORED"}
-            ))
-    except subprocess.CalledProcessError:
-        with open(args.output, "w") as out:
-            out.write(json.dumps(
-                {"submission_status": "INVALID",
-                 "submission_errors": (
-                     "Error encountered during scoring. Please ask a Challenge "
-                     "Organizer for more information."
-                 )}
-            ))
+    results.loc["mean"] = results.mean()
+    results.loc["sd"] = results.std()
+    results.loc["median"] = results.median()
+    results.loc["25quantile"] = results.quantile(q=0.25)
+    results.loc["75quantile"] = results.quantile(q=0.75)
+
+    # CSV file of scores for all scans.
+    results.to_csv("all_scores.csv")
+    syn = synapseclient.Synapse(configPath=args.synapse_config)
+    syn.login(silent=True)
+    csv = synapseclient.File("all_scores.csv", parent=args.parent_id)
+    csv = syn.store(csv)
+
+    # Results file for annotations.
+    with open(args.output, "w") as out:
+        out.write(json.dumps(
+            {**results.loc["mean"].to_dict(),
+                "cases_predicted": cases_predicted,
+                "cases_evaluated": cases_evaluated,
+                "submission_scores": csv.id,
+                "submission_status": "SCORED"}
+        ))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Per Spyros and Ujjwal's request:

> If a single case fails, the workflow should flag that case and then continue the Docker onto the next case; Exclude invalid/errors case from all participant evaluation 

Scoring script will now flag cases that cannot be scored with a `*` and those cases will be given penalized scores of 0 for Dice and 374 for Hausdorff95, e.g.

```python
        scan_id  Dice_ET  Dice_TC  Dice_WT  Hausdorff95_ET  ...  Sensitivity_TC  Sensitivity_WT  Specificity_ET  Specificity_TC  Specificity_WT
BraTS2021_00001      1.0      1.0      1.0             0.0  ...             1.0             1.0             1.0             1.0             1.0
BraTS2021_00013*     0.0      0.0      0.0           374.0  ...             0.0             0.0             0.0             0.0             0.0
```